### PR TITLE
fix: Fix `faces` array type

### DIFF
--- a/src/FaceDetector.ts
+++ b/src/FaceDetector.ts
@@ -22,9 +22,7 @@ export type CallbackType = (
 ) => void | Promise<void>
 
 export interface DetectionResult {
-  faces: {
-    [ index: string ]: Face
-  }
+  faces: Face[]
   frame: FrameData
 }
 


### PR DESCRIPTION
The type should still be array. Only SharedValues are array proxies, but even thhose shhould be typed as arrays since they are behaving like arrays (apart from being console.logged wrong)