### PR TITLE
fix #32 - thanks to @mrousavy

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,16 +30,22 @@ import {
 } from 'react-native'
 import { 
   useEffect, 
-  useState 
+  useState,
+  useRef
 } from 'react'
 import {useCameraDevice} from 'react-native-vision-camera'
 import {
   Camera,
-  DetectionResult
+  DetectionResult,
+  FaceDetectionOptions
 } from 'react-native-vision-camera-face-detector'
 import { Worklets } from 'react-native-worklets-core'
 
 export default function App() {
+  const faceDetectionOptions = useRef<FaceDetectionOptions>( {
+    // detection options
+  } ).current
+
   const device = useCameraDevice('front')
 
   useEffect(() => {
@@ -61,9 +67,7 @@ export default function App() {
         style={StyleSheet.absoluteFill}
         device={device}
         faceDetectionCallback={ handleFacesDetection }
-        faceDetectionOptions={ {
-          // detection settings
-        } }
+        faceDetectionOptions={ faceDetectionOptions }
       /> : <Text>
         No Device
       </Text>}
@@ -81,7 +85,8 @@ import {
 } from 'react-native'
 import { 
   useEffect, 
-  useState 
+  useState,
+  useRef
 } from 'react'
 import {
   Camera,
@@ -89,13 +94,19 @@ import {
   useFrameProcessor
 } from 'react-native-vision-camera'
 import { 
-  detectFaces,
-  DetectionResult 
+  useFrameProcessor,
+  DetectionResult,
+  FaceDetectionOptions
 } from 'react-native-vision-camera-face-detector'
 import { Worklets } from 'react-native-worklets-core'
 
 export default function App() {
+  const faceDetectionOptions = useRef<FaceDetectionOptions>( {
+    // detection options
+  } ).current
+
   const device = useCameraDevice('front')
+  const { detectFaces } = useFrameProcessor( faceDetectionOptions )
 
   useEffect(() => {
     (async () => {
@@ -112,12 +123,16 @@ export default function App() {
   const frameProcessor = useFrameProcessor((frame) => {
     'worklet'
     const result = detectFaces( {
-      frame,
-      options: {
-        // detection settings
-      }
+      frame
     })
+    // do something with frame ...
     handleFacesDetection(result)
+
+    // or
+    detectFaces( {
+      frame,
+      callback: handleFacesDetection
+    } )
   }, [handleFacesDetection])
 
   return (

--- a/example/src/index.tsx
+++ b/example/src/index.tsx
@@ -20,7 +20,8 @@ import { SafeAreaProvider } from 'react-native-safe-area-context'
 import { NavigationContainer } from '@react-navigation/native'
 import {
   Camera,
-  DetectionResult
+  DetectionResult,
+  FaceDetectionOptions
 } from 'react-native-vision-camera-face-detector'
 import Animated, {
   useAnimatedStyle,
@@ -62,6 +63,10 @@ function FaceDetection(): JSX.Element {
     cameraPaused,
     setCameraPaused
   ] = useState<boolean>( false )
+  const faceDetectionOptions = useRef<FaceDetectionOptions>( {
+    performanceMode: 'fast',
+    classificationMode: 'all'
+  } ).current
   const isFocused = useIsFocused()
   const appState = useAppState()
   const isCameraActive = (
@@ -157,10 +162,7 @@ function FaceDetection(): JSX.Element {
           device={ cameraDevice }
           onError={ handleCameraMountError }
           faceDetectionCallback={ handleFacesDetected }
-          faceDetectionOptions={ {
-            performanceMode: 'fast',
-            classificationMode: 'all'
-          } }
+          faceDetectionOptions={ faceDetectionOptions }
         />
 
         <Animated.View

--- a/src/Camera.tsx
+++ b/src/Camera.tsx
@@ -4,7 +4,7 @@ import {
   useFrameProcessor
 } from 'react-native-vision-camera'
 import { useSharedValue } from 'react-native-worklets-core'
-import { detectFaces } from './FaceDetector'
+import { useFaceDetector } from './FaceDetector'
 
 // types
 import type {
@@ -63,6 +63,7 @@ export const Camera = React.forwardRef( ( {
 }: ComponentType,
   ref: ForwardedRef<VisionCamera>
 ) => {
+  const { detectFaces } = useFaceDetector( faceDetectionOptions )
   /** 
    * Is there an async task already running?
    */
@@ -90,8 +91,7 @@ export const Camera = React.forwardRef( ( {
     try {
       detectFaces( {
         frame,
-        callback: faceDetectionCallback,
-        options: faceDetectionOptions
+        callback: faceDetectionCallback
       } )
     } catch ( error: any ) {
       logOnJs( 'Execution error:', error )


### PR DESCRIPTION
Passing options to `initFrameProcessorPlugin` as a second argument which passes them to the native plugin constructor instead of passing along on each call (`callback`)

This is much more efficient.